### PR TITLE
Added safe conversion from unicode to string object; fixes issue #41

### DIFF
--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -1365,6 +1365,23 @@ static int py_netsnmp_attr_string(PyObject *obj, char *attr_name, char **val,
             retval = PyBytes_AsStringAndSize(attr_bytes, val, len);
             //Py_DECREF(attr_bytes);
 #else
+            /* safely convert unicode to string object */
+            if (PyUnicode_Check(attr)) {
+                Py_UNICODE * uniptr = PyUnicode_AS_UNICODE(attr);
+                Py_ssize_t l = PyUnicode_GET_SIZE(attr);
+                char * string = malloc(l);
+                int i;
+                for (i = 0; i < l; ++i)
+                {
+                    string[i] = (char) uniptr[i];
+                }
+                Py_DECREF(attr);
+                attr = PyString_FromStringAndSize(string, l);
+                free(string);
+                if (attr == NULL)
+                    return -1;
+            }
+
             retval = PyString_AsStringAndSize(attr, val, len);
 #endif
 

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -1385,7 +1385,6 @@ static int py_netsnmp_attr_string(PyObject *obj, char *attr_name, char **val,
             retval = PyString_AsStringAndSize(attr, val, len);
 #endif
 
-            Py_DECREF(attr);
             return retval;
         }
     }


### PR DESCRIPTION
Fix Issue #41 by manually converting unicode type objects into string objects. The issue was that PyString_AsStringAndSize defaults to ASCII encoding, and will therefore reject any byte with a value of 0x80 or higher. With this correction, PyString_FromStringAndSize will automatically set the correct encoding to avoid this error