### PR TITLE
Raise Error when py_netsnmp_attr_string fails for 'value' attribute

### DIFF
--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -3879,6 +3879,7 @@ static PyObject *netsnmp_set(PyObject *self, PyObject *args)
 
                 if (py_netsnmp_attr_string(varbind, "value", &val, &tmplen) < 0)
                 {
+                    error = 1;
                     snmp_free_pdu(pdu);
                     pdu = NULL;
                     Py_DECREF(varbind);


### PR DESCRIPTION
simply added an error flag, without which certain errors are not being thrown at the correct time