### PR TITLE
Allow numeric values to be presented as non-string.

### DIFF
--- a/easysnmp/variables.py
+++ b/easysnmp/variables.py
@@ -26,7 +26,7 @@ class SNMPVariable(object):
         self.snmp_type = snmp_type
 
     def __repr__(self):
-        printable_value = strip_non_printable(self.value)
+        printable_value = strip_non_printable(tostr(self.value))
         return (
             "<{0} value={1} (oid={2}, oid_index={3}, snmp_type={4})>".format(
                 self.__class__.__name__,
@@ -36,7 +36,7 @@ class SNMPVariable(object):
         )
 
     def __setattr__(self, name, value):
-        self.__dict__[name] = tostr(value)
+        self.__dict__[name] = value
 
 
 class SNMPVariableList(list):


### PR DESCRIPTION
Values that are of data types INTEGER, COUNTER, COUNTER64, GAUGE, TICKS, etc should be accessible as their numeric types. At the moment, to access them as their native types, a re-conversion from string needs to be made. I suggest moving string (tostr) conversions only in __repr__.