### PR TITLE
Add equality comparison to SNMPVariable for easier use in tests

### DIFF
--- a/easysnmp/variables.py
+++ b/easysnmp/variables.py
@@ -38,6 +38,9 @@ class SNMPVariable(object):
     def __setattr__(self, name, value):
         self.__dict__[name] = tostr(value)
 
+    def __eq__(self, other):
+        return repr(self) == repr(other)
+
 
 class SNMPVariableList(list):
     """


### PR DESCRIPTION
This PR implements `__eq__` for comparing `SNMPVariable` objects, which is useful in tests. Hope it helps someone.