### PR TITLE
Allow use the tcp protocol prefix in the session hostname parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/_build/
 
 # vim stuff
 .ropeproject
+
+# virtualenv
+.venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 addopts = -s --cov=easysnmp --cov-report=term-missing --flake8
 flake8-ignore =
     build/*.py ALL

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import logging
 
-import pytest
 import easysnmp
 
 # Disable logging for the C interface
@@ -10,7 +9,6 @@ snmp_logger = logging.getLogger('easysnmp.interface')
 snmp_logger.disabled = True
 
 
-@pytest.fixture
 def sess_v1_args():
     return {
         'version': 1,
@@ -20,7 +18,6 @@ def sess_v1_args():
     }
 
 
-@pytest.fixture
 def sess_v2_args():
     return {
         'version': 2,
@@ -30,7 +27,6 @@ def sess_v2_args():
     }
 
 
-@pytest.fixture
 def sess_v3_args():
     return {
         'version': 3,
@@ -43,16 +39,13 @@ def sess_v3_args():
     }
 
 
-@pytest.fixture
 def sess_v1():
     return easysnmp.Session(**sess_v1_args())
 
 
-@pytest.fixture
 def sess_v2():
     return easysnmp.Session(**sess_v2_args())
 
 
-@pytest.fixture
 def sess_v3():
     return easysnmp.Session(**sess_v3_args())


### PR DESCRIPTION
Hi @kamakazikamikaze !

**What happened**
I found one behavior in session class. When parsing parameter `hostname` In constructor method only providing  to use hostname and remote port. NetSnmp also provide using protocol (tcp) in hostname by example `snmpwalk -v3 -u admin -l noAuthNoPriv tcp:127.0.0.1:161 1.3.6.1.4.1`.

**What I done**
Little changed parsing of hostname parameter. Right now as remote port will take last element of hostname string that was sptitted by ":", other part will use as hostname.
I also removed decorators in all functions in `fixtures` module. Just fixtures cant be called directly on pytest.