### PR TITLE
[Python 3.7 compat] Properly handle Python Exceptions with __send_sync_pdu()

### DIFF
--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -1457,6 +1457,9 @@ static void __py_netsnmp_update_session_errors(PyObject *session,
                                                int err_ind)
 {
     PyObject *tmp_for_conversion;
+    PyObject *type, *value, *traceback;
+
+    PyErr_Fetch(&type, &value, &traceback);
 
     py_netsnmp_attr_set_string(session, "error_string", err_str,
                                STRLEN(err_str));
@@ -1464,7 +1467,7 @@ static void __py_netsnmp_update_session_errors(PyObject *session,
     tmp_for_conversion = PyLong_FromLong(err_num);
     if (!tmp_for_conversion)
     {
-        return; /* nothing better to do? */
+        goto done; /* nothing better to do? */
     }
     PyObject_SetAttrString(session, "error_number", tmp_for_conversion);
     Py_DECREF(tmp_for_conversion);
@@ -1472,10 +1475,15 @@ static void __py_netsnmp_update_session_errors(PyObject *session,
     tmp_for_conversion = PyLong_FromLong(err_ind);
     if (!tmp_for_conversion)
     {
-        return; /* nothing better to do? */
+        goto done; /* nothing better to do? */
     }
     PyObject_SetAttrString(session, "error_index", tmp_for_conversion);
     Py_DECREF(tmp_for_conversion);
+
+done:
+    PyErr_Restore(type, value, traceback);
+
+    return;
 }
 
 /*


### PR DESCRIPTION
This replaces PR #117, which is a bit messy and doesn't solve the bug's root cause; that PyObject_SetAttr\*() clears the exception raised by __send_sync_pdu().

@kamakazikamikaze : I know you haven't been active here for quite some time, but I kindly ask for a review of this small patch please!

commit message:

----

Between __send_sync_pdu() seting the Error Indicator, and us checking
its return value, we call __py_netsnmp_update_session_errors().
__py_netsnmp_update_session_errors() calls PyObject_SetAttrString(),
which (on Python 3.7+) resets the Error Indicator, causing the exception
to be dropped.

This patch saves the exception before PyObject_SetAttrString() gets
called and restores it afterwards.

---

fixes #108 and closes #117
