### PR TITLE
Allow manual dispatch of GA events

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - 'master'
       - 'actions'
+  workflow_dispatch:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This is *intended* to allow manually running the workflow for pull requests, but it may not work that way.