### PR TITLE
Memory leak patches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,10 @@
 name: tests
 on:
   push:
-    branches:
-      - 'actions-test'
-  pull_request:
-    branches:
+    branches-ignore:
       - 'master'
       - 'actions'
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -86,7 +84,15 @@ jobs:
           fi
           if [[ "${{ matrix.python-version }}" =~ "3.10" ]] && [ "$RUNNER_OS" == "Linux" ]
           then
-            VALGRIND="valgrind --leak-check=full --show-reachable=no --log-file=./valgrind.out"
+            wget https://raw.githubusercontent.com/python/cpython/main/Misc/valgrind-python.supp
+            VALGRIND=(
+              'valgrind'
+              '--tool=memcheck'
+              '--leak-check=full'
+              '--show-leak-kinds=definite,indirect,possible'
+              '--suppressions=./valgrind-python.supp'
+              '--log-file=./valgrind.out'
+            )
             echo 'PYTHONMALLOC=malloc' >> $GITHUB_ENV
           fi
           ${VALGRIND[@]} python -m pytest ${PYTEST_ARGS[@]} --junitxml=test-results_${{ matrix.os }}_${{ matrix.python-version }}.xml | tee ./test-outputs_${{ matrix.os }}_${{ matrix.python-version }}.log

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ docs/_build/
 
 # vim stuff
 .ropeproject
+
+# Local development
+dev/
+.vscode
+*/*.log
+*.log

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -3004,6 +3004,11 @@ done:
         snmp_free_pdu(response);
         response = NULL;
     }
+    if (pdu)
+    {
+        snmp_free_pdu(pdu);
+        response = NULL;
+    }
     if (error)
     {
         return NULL;
@@ -4031,7 +4036,9 @@ done:
 static void py_log_msg(int log_level, char *printf_fmt, ...)
 {
     PyObject *log_msg = NULL;
+    PyObject *type, *value, *traceback;
     va_list fmt_args;
+    PyErr_Fetch(&type, &value, &traceback);
 
     va_start(fmt_args, printf_fmt);
     log_msg = PyUnicode_FromFormatV(printf_fmt, fmt_args);
@@ -4070,6 +4077,7 @@ static void py_log_msg(int log_level, char *printf_fmt, ...)
             break;
     }
 
+    PyErr_Restore(type, value, traceback);
     Py_DECREF(log_msg);
 }
 

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -1513,12 +1513,10 @@ static int py_netsnmp_attr_string(PyObject *obj, char *attr_name, char **val,
             *attr_bytes = PyUnicode_AsEncodedString(attr, "latin-1", "surrogateescape");
             if (!attr_bytes)
             {
-                /* Needs decrement? */
-                Py_XDECREF(attr);
+                Py_DECREF(attr);
                 return -1;
             }
             retval = PyBytes_AsStringAndSize(*attr_bytes, val, len);
-            //Py_DECREF(attr_bytes);
 #else
             retval = PyString_AsStringAndSize(attr, val, len);
 #endif
@@ -2265,7 +2263,7 @@ static PyObject *netsnmp_get(PyObject *self, PyObject *args)
             {
                 py_log_msg(DEBUG, "netsnmp_get: bad varbind (%d)",
                            varlist_ind);
-                Py_XDECREF(varbind);
+                // Py_XDECREF(varbind); Double DECREF?
             }
 
             py_netsnmp_attr_set_string(varbind, "snmp_type", "NOSUCHNAME",
@@ -2363,7 +2361,7 @@ done:
     {
         return NULL;
     }
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
@@ -2713,7 +2711,7 @@ done:
     {
         return NULL;
     }
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
@@ -3160,7 +3158,7 @@ done:
     {
         return NULL;
     }
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
@@ -3483,7 +3481,7 @@ done:
     {
         return NULL;
     }
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args) {
@@ -3933,7 +3931,7 @@ done:
     {
         return NULL;
     }
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 static PyObject *netsnmp_set(PyObject *self, PyObject *args)

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -1706,25 +1706,19 @@ static PyObject *netsnmp_create_session_v3(PyObject *self, PyObject *args)
 #ifndef DISABLE_MD5
     if (!strcmp(auth_proto, "MD5"))
     {
-        session.securityAuthProto =
-            snmp_duplicate_objid(usmHMACMD5AuthProtocol,
-                                 USM_AUTH_PROTO_MD5_LEN);
+        session.securityAuthProto = usmHMACMD5AuthProtocol;
         session.securityAuthProtoLen = USM_AUTH_PROTO_MD5_LEN;
     }
     else
 #endif
     if (!strcmp(auth_proto, "SHA"))
     {
-        session.securityAuthProto =
-            snmp_duplicate_objid(usmHMACSHA1AuthProtocol,
-                                 USM_AUTH_PROTO_SHA_LEN);
+        session.securityAuthProto = usmHMACSHA1AuthProtocol;
         session.securityAuthProtoLen = USM_AUTH_PROTO_SHA_LEN;
     }
     else if (!strcmp(auth_proto, "DEFAULT"))
     {
-        const oid* a = get_default_authtype(&session.securityAuthProtoLen);
-        session.securityAuthProto
-            = snmp_duplicate_objid(a, session.securityAuthProtoLen);
+        session.securityAuthProto = (oid *) get_default_authtype(&session.securityAuthProtoLen);
     }
     else
     {
@@ -1753,25 +1747,19 @@ static PyObject *netsnmp_create_session_v3(PyObject *self, PyObject *args)
 #ifndef DISABLE_DES
     if (!strcmp(priv_proto, "DES"))
     {
-        session.securityPrivProto =
-            snmp_duplicate_objid(usmDESPrivProtocol,
-                                 USM_PRIV_PROTO_DES_LEN);
+        session.securityPrivProto = usmDESPrivProtocol;
         session.securityPrivProtoLen = USM_PRIV_PROTO_DES_LEN;
     }
     else
 #endif
     if (!strncmp(priv_proto, "AES", 3))
     {
-        session.securityPrivProto =
-            snmp_duplicate_objid(usmAESPrivProtocol,
-                                 USM_PRIV_PROTO_AES_LEN);
+        session.securityPrivProto = usmAESPrivProtocol;
         session.securityPrivProtoLen = USM_PRIV_PROTO_AES_LEN;
     }
     else if (!strcmp(priv_proto, "DEFAULT"))
     {
-        const oid *p = get_default_privtype(&session.securityPrivProtoLen);
-        session.securityPrivProto =
-            snmp_duplicate_objid(p, session.securityPrivProtoLen);
+        session.securityPrivProto = (oid *) get_default_privtype(&session.securityPrivProtoLen);
     }
     else
     {

--- a/tests/snmpd.conf
+++ b/tests/snmpd.conf
@@ -69,6 +69,7 @@ group MyRWGroup	v1         local
 group MyRWGroup	v2c        local
 group MyRWGroup	usm        local
 group MyRWGroup	usm        initial
+group MyRWGroup usm        secondary
 group MyROGroup v1         mynetwork
 group MyROGroup v2c        mynetwork
 group MyROGroup usm        mynetwork
@@ -91,6 +92,8 @@ access MyRWGroup ""      any       noauth    exact  all    all    none
 
 rwuser initial priv 
 createUser initial MD5 auth_pass DES priv_pass
+rwuser secondary priv
+createUser secondary SHA auth_second AES priv_second
 
 ###############################################################################
 # System contact information


### PR DESCRIPTION
Fixes memory leak caused by not DECREF'ing the object created by `PyLogger`.
Fixes memory leak caused by not DECREF'ing the object created by `py_netsnmp_attr_string`.
Fixes memory leak caused by not free'ing malloc assignments in `netsnmp_create_session_v3`.
Add support for SHA224, SHA256, SHA384, SHA512, AES192, AES256, and Cisco-style AES.
Suppresses Valgrind messages caused from Python's internal memory handling.
Fixes error that can be raised by attempting to use `PyLogger` when a Python exception is queued.

* Closes #141 
* Closes #115 
* Closes #46 
* Closes #45 
