### PR TITLE
fix compilation for configurable privacy/authentication algorithms

### DIFF
--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -274,7 +274,7 @@ static int __match_algo(int is_auth, char *algo, oid **output, size_t *len)
         }
 #endif // NETSNMP_DISABLE_DES
 #ifdef HAVE_AES
-#ifndef NETSNMP_DISABLE_AES
+#ifndef NETSNMP_DISABLE_DES
         else if (strcmp(algo, "AES128") == 0 ||
 #else
         if (strcmp(algo, "AES128") == 0 ||


### PR DESCRIPTION
I'm not sure if this was a typo? 

otherwise, cc fails here:

```
    easysnmp/interface.c: In function ‘__match_algo’:
    easysnmp/interface.c:278:9: error: ‘else’ without a previous ‘if’
      278 |         else if (strcmp(algo, "AES128") == 0 ||
          |         ^~~~
```