### PR TITLE
Only run test checks if source code or package build files are changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create manylinux wheels
         uses: RalfG/python-wheels-manylinux-build@v0.4.2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,30 @@ on:
   pull_request:
 
 jobs:
+  check-source-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run_job: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - name: Checkout changes
+        uses: actions/checkout@v3
+      - name: Check for changes in source code
+        id: changed-files
+        uses: tj-actions/changed-files@v18.7
+        with:
+          files: |
+            easysnmp/*.py
+            easysnmp/*.c
+            easysnmp/*.h
+            setup.py
+            setup.cfg
+            setup-py2.7.cfg
+            .github/workflows/*.yml
+
   build-and-test:
     runs-on: ${{ matrix.os }}
+    needs: check-source-changes
+    if: needs.check-source-changes.outputs.run_job == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +60,7 @@ jobs:
           echo 'mibs +ALL' > ~/.snmp/snmp.conf
         shell: bash
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Easy SNMP'
-copyright = '2015, Fotis Gimian'
-author = 'Fotis Gimian'
+copyright = '2015-2022, Fotis Gimian, Kent Coble'
+author = 'Fotis Gimian, Kent Coble'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -9,9 +9,9 @@
  * to provide backwards compatibility.
  */
 #if (                                  \
-    ((PY_VERSION_HEX < 0x02070000) ||  \
-     (PY_VERSION_HEX >= 0x03000000) && \
-         (PY_VERSION_HEX < 0x03010000)))
+    (PY_VERSION_HEX < 0x02070000) ||   \
+    ((PY_VERSION_HEX >= 0x03000000) && \
+     (PY_VERSION_HEX < 0x03010000)))
 
 #define USE_DEPRECATED_COBJECT_API
 


### PR DESCRIPTION
Only runs tests if the following files are changed:

* `easysnmp/*.{py,c,h}`
* `setup.{py,cfg}`
* `setup-py2.7.cfg`
* `.github/workflows/*.yml`

This should minimize unnecessary runtime of Github Actions.

Also corrects the Python version check in `interface.c` to be true _if_ Python <2.7 or Python 3.0 is used.