### PR TITLE
Improve session hostname parameter supporting IPv6

### DIFF
--- a/easysnmp/session.py
+++ b/easysnmp/session.py
@@ -203,10 +203,10 @@ class Session(object):
         retry_no_such=False,
         abort_on_nonexistent=False,
     ):
-
         # Validate and extract the remote port
         connection_string = re.match(
-            r"^((?:tcp6?:|udp6?:)?\[?([^\[\]]+?)\]?)\:(\d+)$", hostname)
+            r"^((?:tcp6?:|udp6?:)?\[?([^\[\]]+?)\]?)\:(\d+)$", hostname
+        )
         if connection_string:
             if remote_port:
                 raise ValueError(
@@ -216,9 +216,7 @@ class Session(object):
             else:
                 full_address, hostname, remote_port = connection_string.groups()
                 if ":" in hostname and not hostname_is_IPv6(hostname):
-                    raise ValueError(
-                        "an invalid IPv6 address was specified"
-                    )
+                    raise ValueError("an invalid IPv6 address was specified")
                 hostname = full_address
                 remote_port = int(remote_port)
 
@@ -275,7 +273,6 @@ class Session(object):
 
     @property
     def connect_hostname(self):
-
         def format_hostname(hostname):
             return "[{}]".format(hostname) if hostname_is_IPv6(hostname) else hostname
 

--- a/easysnmp/utils.py
+++ b/easysnmp/utils.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals, absolute_import
 
+import ipaddress
 import string
 
 from .compat import ub, text_type
@@ -45,3 +46,12 @@ def tostr(value):
         return str(value)
     else:
         return ub(value)
+
+
+def hostname_is_IPv6(hostname):
+    try:
+        ipaddress.IPv6Address(hostname)
+    except ipaddress.AddressValueError:
+        return False
+    else:
+        return True

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -57,7 +57,11 @@ def test_session_ipv6_address(version):
 
 @pytest.mark.parametrize("version", [1, 2, 3])
 def test_session_ipv6_address_and_remote_port(version):
-    session = Session(hostname="fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa", remote_port=162, version=version)
+    session = Session(
+        hostname="fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa",
+        remote_port=162,
+        version=version,
+    )
     assert session.hostname == "fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa"
     assert session.remote_port == 162
     assert session.connect_hostname == "[fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa]:162"
@@ -95,7 +99,11 @@ def test_session_ipv6_is_not_ipv6(version):
 @pytest.mark.parametrize("version", [1, 2, 3])
 def test_session_ipv6_invalid_hostname_and_remote_port(version):
     with pytest.raises(ValueError):
-        Session(hostname="[fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa]:161", remote_port=162, version=version)
+        Session(
+            hostname="[fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa]:161",
+            remote_port=162,
+            version=version,
+        )
 
 
 def test_session_set_multiple_next(sess, reset_values):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -48,6 +48,56 @@ def test_session_invalid_port(version):
         session.get("sysContact.0")
 
 
+@pytest.mark.parametrize("version", [1, 2, 3])
+def test_session_ipv6_address(version):
+    session = Session(hostname="2001:db8::", version=version)
+    assert session.hostname == "2001:db8::"
+    assert session.connect_hostname == "2001:db8::"
+
+
+@pytest.mark.parametrize("version", [1, 2, 3])
+def test_session_ipv6_address_and_remote_port(version):
+    session = Session(hostname="fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa", remote_port=162, version=version)
+    assert session.hostname == "fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa"
+    assert session.remote_port == 162
+    assert session.connect_hostname == "[fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa]:162"
+
+
+@pytest.mark.parametrize("version", [1, 2, 3])
+def test_session_ipv6_address_and_remote_port_split(version):
+    session = Session(hostname="[2001:db8::]:161", version=version)
+    assert session.hostname == "[2001:db8::]"
+    assert session.remote_port == 161
+    assert session.connect_hostname == "[2001:db8::]:161"
+
+
+@pytest.mark.parametrize("version", [1, 2, 3])
+def test_session_ipv6_address_with_protocol_and_remote_port_split(version):
+    session = Session(hostname="udp6:[2001:db8::]:162", version=version)
+    assert session.hostname == "udp6:[2001:db8::]"
+    assert session.remote_port == 162
+    assert session.connect_hostname == "udp6:[2001:db8::]:162"
+
+
+@pytest.mark.parametrize("version", [1, 2, 3])
+def test_session_ipv6_address_with_protocol(version):
+    session = Session(hostname="udp6:[2001:db8::]", version=version)
+    assert session.hostname == "udp6:[2001:db8::]"
+    assert session.connect_hostname == "udp6:[2001:db8::]"
+
+
+@pytest.mark.parametrize("version", [1, 2, 3])
+def test_session_ipv6_is_not_ipv6(version):
+    with pytest.raises(ValueError):
+        Session(hostname="[foo::bar]:161", version=version)
+
+
+@pytest.mark.parametrize("version", [1, 2, 3])
+def test_session_ipv6_invalid_hostname_and_remote_port(version):
+    with pytest.raises(ValueError):
+        Session(hostname="[fd5d:12c9:2201:1:bc9c:f8ff:fe5c:57fa]:161", remote_port=162, version=version)
+
+
 def test_session_set_multiple_next(sess, reset_values):
     # Destroy succeeds even if no row exists
     sess.set(".1.3.6.1.6.3.12.1.2.1.9.116.101.115.116", 6)

--- a/tests/test_v3_cache.py
+++ b/tests/test_v3_cache.py
@@ -7,7 +7,7 @@ from easysnmp.exceptions import EasySNMPConnectionError
 
 def test_v3_not_caching_user(sess_v3):
     s = Session(**sess_v3)
-    res = s.get('sysDescr.0')
+    res = s.get("sysDescr.0")
 
     assert res.oid == "sysDescr"
     assert res.oid_index == "0"
@@ -15,7 +15,7 @@ def test_v3_not_caching_user(sess_v3):
     s.update_session(privacy_password="wrong_pass")
 
     with pytest.raises(EasySNMPConnectionError):
-        res = s.get('sysDescr.0')
+        res = s.get("sysDescr.0")
 
     d = dict(**sess_v3)
     d["privacy_password"] = "wrong_pass"
@@ -24,7 +24,7 @@ def test_v3_not_caching_user(sess_v3):
         res = s.get("sysDescr.0")
 
     s.update_session(privacy_password="priv_pass")
-    res = s.get('sysDescr.0')
+    res = s.get("sysDescr.0")
 
     assert res.oid == "sysDescr"
     assert res.oid_index == "0"


### PR DESCRIPTION
This pull request adds support to ipv6 connection strings, closes: https://github.com/easysnmp/easysnmp/issues/47

Also the protocol can be specified (tcp|udp): https://github.com/easysnmp/easysnmp/pull/120